### PR TITLE
fix: collapse button rotating to right when menu is collapsed

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -135,6 +135,10 @@
 .collapseMenuItem {
   display: none;
 
+  &.collapsed {
+    transform: rotate(180deg);
+  }
+
   @media (min-width: breakpoint.$desktop) {
     display: flex;
   }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,10 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(
+                styles.collapseMenuItem,
+                isSidebarCollapsed && styles.collapsed,
+              )}
             />
           </ul>
         </nav>


### PR DESCRIPTION
Fixing collapse menu icon to point to right position when menu is collapsed